### PR TITLE
Adding chartbeat loads to the list of items not to trigger a push

### DIFF
--- a/KPCC/UI/Controllers/Headlines/SCPRShortListViewController.m
+++ b/KPCC/UI/Controllers/Headlines/SCPRShortListViewController.m
@@ -204,7 +204,13 @@ static NSString *kShortListMenuURL = @"http://www.scpr.org/short-list/latest#no-
             if ( [str rangeOfString:@"pageview?"].location != NSNotFound ) {
                 return YES;
             }
+            if ( [str rangeOfString:@"chartbeat"].location != NSNotFound ) {
+                return YES;
+            }
             if ( [str rangeOfString:@"http"].location != NSNotFound ) {
+                
+                NSLog(@"Headlines electing to load : %@",str);
+                
                 if ( !self.pushing ) {
                     
                     [SCPRSpinnerViewController spinInCenterOfViewController:self appeared:^{


### PR DESCRIPTION
Fixes a bug causing Headlines to attempt to load chartbeat analysis into its own browser.